### PR TITLE
Fix declaration error for function 'strerror'

### DIFF
--- a/src/ReadFiles.cpp
+++ b/src/ReadFiles.cpp
@@ -24,6 +24,8 @@
 #include <regex>
 #include <utility>
 #include <vector>
+#include <cerrno>
+#include <cstring>
 
 #include "Atom.h"
 
@@ -117,7 +119,7 @@ Cell read_CAR(std::string file_name) {
     std::cout << "Unable to read file: "
               << file_name
               << " ("
-              << strerror(errno)
+              << std::strerror(errno)
               << ")."
               << std::endl;
     exit(1);
@@ -269,7 +271,7 @@ Cell read_CELL(std::string file_name) {
     std::cout << "Unable to read file: "
               << file_name
               << " ("
-              << strerror(errno)
+              << std::strerror(errno)
               << ")."
               << std::endl;
     exit(1);
@@ -441,7 +443,7 @@ Cell read_ONETEP_DAT(std::string file_name) {
     std::cout << "Unable to read file: "
               << file_name
               << " ("
-              << strerror(errno)
+              << std::strerror(errno)
               << ")."
               << std::endl;
     exit(1);


### PR DESCRIPTION
version (or branch): 'main' branch: f0965a049609074d622d213e8b4b23e29c5363c2
OS: Arch Linux
compiler and compiler version: gcc-12.1.0

issue: When following the instructions in README.md and compiling the code, the compiler gave the error that function 'strerror' does not declared. 

I have made some changes to the source code and fixed the problem.